### PR TITLE
fix api_version du clusterrole

### DIFF
--- a/sources/prometheus/clusterRole.yaml
+++ b/sources/prometheus/clusterRole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: prometheus
@@ -19,7 +19,7 @@ rules:
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus


### PR DESCRIPTION
la version de l'api des clusterroles et clusterroles binding n'est plus compatoble avec notre version la version de minikube  que nous fournissons sur vagrant